### PR TITLE
[FIX] UIStartHandler 중복 추가 fix

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -18,7 +18,6 @@ public class GameManager : MonoBehaviour
 
     private BoxCollider2D playerCollider;
 
-
     public const string UIMAINHANDLER_NAME = "uiMainHandler";
     public const string SAMPLESCENE = "SampleScene";
     
@@ -114,6 +113,7 @@ public class GameManager : MonoBehaviour
     {
         PlayerController.IsDead = false;
         Time.timeScale = 1;
+
         UIManager.Instance.RemoveUIScript(UIMAINHANDLER_NAME);
         SceneManager.LoadScene("StartScene");
         AudioManager.Instance.PlaySfx(AudioManager.Sfx.button);

--- a/Assets/Scripts/StartSceneManager.cs
+++ b/Assets/Scripts/StartSceneManager.cs
@@ -59,6 +59,7 @@ public class StartSceneManager : MonoBehaviour
     {
         AudioManager.Instance.PlaySfx(AudioManager.Sfx.button);
         PlayerPrefs.SetInt(PLAYERPREFS_CHARACTERNUMBER, (int)characterName);
+        UIManager.Instance.RemoveUIScript(UIHANDLER_NAME);
         SceneManager.LoadScene(SAMPLESCENE); 
     }
 


### PR DESCRIPTION
UIStartHandler가 MainScene에서 StartScene으로 넘어가면서 새로 생성되어 UIManager에 저장되어 있는 스크립트랑 달라서 원래 있는 스크립트는 MainScene 넘어갈 때 지워줌